### PR TITLE
Add specific user-agent header for health checks

### DIFF
--- a/src/model/kube/statusFetcher.go
+++ b/src/model/kube/statusFetcher.go
@@ -69,7 +69,7 @@ type (
 	}
 )
 
-var healthCheckUserAgent = "VistectureDashboard"
+const healthCheckUserAgent = "VistectureDashboard"
 
 var (
 	healthcheck = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/src/model/kube/statusFetcher.go
+++ b/src/model/kube/statusFetcher.go
@@ -453,7 +453,7 @@ func checkHealth(status AppDeploymentInfo, checkBaseUrl string, healtcheckPath s
 		return false, reqErr.Error(), HealthCheckType_NotCheckedYet
 	}
 
-	req.Header.Add("user-agent", healthCheckUserAgent)
+	req.Header.Set("User-Agent", healthCheckUserAgent)
 	r, httpErr := client.Do(req)
 
 	if httpErr != nil {

--- a/src/model/kube/statusFetcher.go
+++ b/src/model/kube/statusFetcher.go
@@ -69,6 +69,8 @@ type (
 	}
 )
 
+var healthCheckUserAgent = "VistectureDashboard"
+
 var (
 	healthcheck = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "application_health_status",
@@ -443,7 +445,16 @@ func checkPublicHealth(ingresses []K8sIngressInfo, healtcheckPath string) bool {
 
 func checkHealth(status AppDeploymentInfo, checkBaseUrl string, healtcheckPath string) (bool, string, string) {
 	checkUrl := checkBaseUrl + healtcheckPath
-	r, httpErr := http.Get(checkUrl)
+
+	client := &http.Client{}
+
+	req, reqErr := http.NewRequest("GET", checkUrl, nil)
+	if reqErr != nil {
+		return false, reqErr.Error(), HealthCheckType_NotCheckedYet
+	}
+
+	req.Header.Add("user-agent", healthCheckUserAgent)
+	r, httpErr := client.Do(req)
 
 	if httpErr != nil {
 		return false, httpErr.Error(), HealthCheckType_NotCheckedYet

--- a/src/model/kube/statusFetcher_test.go
+++ b/src/model/kube/statusFetcher_test.go
@@ -30,3 +30,21 @@ func TestCheckHealth_UnhealthyService(t *testing.T) {
 		t.Errorf("healthStatusOfService should be false")
 	}
 }
+
+func TestCheckHealth_UserAgentIsSet(t *testing.T) {
+	expectedUA := "VistectureDashboard"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ua := r.Header.Get("User-Agent")
+		if ua != expectedUA {
+			w.WriteHeader(500)
+			t.Errorf("expected user-agent to be '%s' but was '%s'", expectedUA, ua)
+		} else {
+			w.WriteHeader(200)
+		}
+	}))
+
+	healthStatusOfService, _, _ := checkHealth(AppDeploymentInfo{}, server.URL, "/")
+	if healthStatusOfService {
+		t.Errorf("user-agent assertion failed")
+	}
+}

--- a/src/model/kube/statusFetcher_test.go
+++ b/src/model/kube/statusFetcher_test.go
@@ -12,7 +12,7 @@ func TestCheckHealth_AllHealthy(t *testing.T) {
 
 	}))
 	defer server.Close()
-	
+
 	healthStatusOfService, reason, _ := checkHealth(AppDeploymentInfo{}, server.URL, "/")
 	if !healthStatusOfService {
 		t.Errorf("healthStatusOfService should be true %v", reason)
@@ -24,7 +24,7 @@ func TestCheckHealth_UnhealthyService(t *testing.T) {
 		w.Write([]byte("{\"services\": [{\"name\": \"dummy\", \"alive\": false, \"details\": \"dummy\"}]}"))
 	}))
 	defer server.Close()
-	
+
 	healthStatusOfService, _, _ := checkHealth(AppDeploymentInfo{}, server.URL, "/nonexistingpath")
 	if healthStatusOfService {
 		t.Errorf("healthStatusOfService should be false")
@@ -42,6 +42,7 @@ func TestCheckHealth_UserAgentIsSet(t *testing.T) {
 			w.WriteHeader(200)
 		}
 	}))
+	defer server.Close()
 
 	healthStatusOfService, _, _ := checkHealth(AppDeploymentInfo{}, server.URL, "/")
 	if healthStatusOfService {

--- a/src/model/kube/statusFetcher_test.go
+++ b/src/model/kube/statusFetcher_test.go
@@ -11,7 +11,8 @@ func TestCheckHealth_AllHealthy(t *testing.T) {
 		w.Write([]byte("{\"services\": []}"))
 
 	}))
-
+	defer server.Close()
+	
 	healthStatusOfService, reason, _ := checkHealth(AppDeploymentInfo{}, server.URL, "/")
 	if !healthStatusOfService {
 		t.Errorf("healthStatusOfService should be true %v", reason)

--- a/src/model/kube/statusFetcher_test.go
+++ b/src/model/kube/statusFetcher_test.go
@@ -1,0 +1,30 @@
+package kube
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCheckHealth_AllHealty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("{\"services\": []}"))
+
+	}))
+
+	healthStatusOfService, reason, _ := checkHealth(AppDeploymentInfo{}, server.URL, "/")
+	if !healthStatusOfService {
+		t.Errorf("healthStatusOfService should be true %v", reason)
+	}
+}
+
+func TestCheckHealth_UnhealthyService(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("{\"services\": [{\"name\": \"dummy\", \"alive\": false, \"details\": \"dummy\"}]}"))
+	}))
+
+	healthStatusOfService, _, _ := checkHealth(AppDeploymentInfo{}, server.URL, "/nonexistingpath")
+	if healthStatusOfService {
+		t.Errorf("healthStatusOfService should be false")
+	}
+}

--- a/src/model/kube/statusFetcher_test.go
+++ b/src/model/kube/statusFetcher_test.go
@@ -22,7 +22,8 @@ func TestCheckHealth_UnhealthyService(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("{\"services\": [{\"name\": \"dummy\", \"alive\": false, \"details\": \"dummy\"}]}"))
 	}))
-
+	defer server.Close()
+	
 	healthStatusOfService, _, _ := checkHealth(AppDeploymentInfo{}, server.URL, "/nonexistingpath")
 	if healthStatusOfService {
 		t.Errorf("healthStatusOfService should be false")

--- a/src/model/kube/statusFetcher_test.go
+++ b/src/model/kube/statusFetcher_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestCheckHealth_AllHealty(t *testing.T) {
+func TestCheckHealth_AllHealthy(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("{\"services\": []}"))
 


### PR DESCRIPTION
The default useragent is gohttp/version. with this useragent it is hard to detect te source-appliction. of request in access-logfiles.

* added an user-agent header for all health-check requests
* additional i added an basic test for the existing checkHealth method