### PR TITLE
Prefer direct path ingresses

### DIFF
--- a/src/model/kube/statusFetcher.go
+++ b/src/model/kube/statusFetcher.go
@@ -53,6 +53,7 @@ type (
 	K8sIngressInfo struct {
 		URL   string
 		Host  string
+		Path  string
 		Alive bool
 	}
 


### PR DESCRIPTION
This should fix #11. It sorts the available ingresses by their path's length and thus prefers ingresses which directly access the application over ones where the backend is put behind a different path.