### PR TITLE
chore: Implement functionality to override the k8sDeploymentName parameter

### DIFF
--- a/src/model/kube/fakeData.go
+++ b/src/model/kube/fakeData.go
@@ -196,7 +196,12 @@ func (d *DemoService) GetServices() (map[string]v1.Service, error) {
 	return services, nil
 }
 
+// GetConfigMaps returns fake config maps
+func (d *DemoService) GetConfigMaps() (map[string]v1.ConfigMap, error) {
+	return nil, nil
+}
+
 // GetJobsByApp returns jobs matching app names
-func (k *DemoService) GetJobsByApp() (map[string][]batchV1.Job, error) {
+func (d *DemoService) GetJobsByApp() (map[string][]batchV1.Job, error) {
 	return nil, nil
 }

--- a/src/model/kube/k8s.go
+++ b/src/model/kube/k8s.go
@@ -31,6 +31,7 @@ type (
 		GetKubernetesDeployments() (map[string]apps.Deployment, error)
 		GetIngressesByService() (map[string][]K8sIngressInfo, error)
 		GetServices() (map[string]v1.Service, error)
+		GetConfigMaps() (map[string]v1.ConfigMap, error)
 		GetJobsByApp() (map[string][]v1Batch.Job, error)
 	}
 
@@ -165,6 +166,31 @@ func (k *KubeInfoService) GetServices() (map[string]v1.Service, error) {
 
 	}
 	return serviceIndex, nil
+}
+
+func (k *KubeInfoService) GetConfigMaps() (map[string]v1.ConfigMap, error) {
+
+	client, err := KubeClientFromConfig()
+
+	if err != nil {
+		return nil, err
+	}
+
+	configMapClient := client.Clientset.CoreV1().ConfigMaps(client.Namespace)
+	configMaps, err := configMapClient.List(context.Background(), metav1.ListOptions{})
+
+	if err != nil {
+		return nil, err
+	}
+
+	configMapIndex := make(map[string]v1.ConfigMap)
+	log.Printf("K8s: found %v ConfigMaps..\n", len(configMaps.Items))
+
+	for _, configMap := range configMaps.Items {
+		configMapIndex[configMap.Name] = configMap
+
+	}
+	return configMapIndex, nil
 }
 
 func (k *KubeInfoService) GetJobsByApp() (map[string][]v1Batch.Job, error) {


### PR DESCRIPTION
- Add a function to get all config maps of a Kubernetes cluster
- When "k8sDeploymentName" is found in the config map, it will override the k8sDeploymentName parameter of the app with the value of the config map.