### PR TITLE
chore: If `k8sHealthCheckThroughIngress` is not set, there is no need for calling the ingress

### DIFF
--- a/src/model/kube/statusFetcher.go
+++ b/src/model/kube/statusFetcher.go
@@ -429,13 +429,13 @@ func checkDeploymentWithHealthCheck(name string, app *vistectureCore.Application
 		return d
 	}
 
-	// Try to do the healthcheck also from (public) ingress - if an ingress exist and the check from service was ok
-	if len(k8sIngresses[k8sHealthCheckServiceName]) > 0 {
-		d.AppStateInfo.HealthyAlsoFromIngress = checkPublicHealth(k8sIngresses[k8sHealthCheckServiceName], app.Properties["healthCheckPath"])
-	}
-
-	// In case the application need to be checked from outside - let it fail
+	// In case the application need to be checked from outside, do the check and let it fail if unhealthy/misconfigured
 	if _, ok := app.Properties["k8sHealthCheckThroughIngress"]; ok {
+		// Try to do the healthcheck from ingress
+		if len(k8sIngresses[k8sHealthCheckServiceName]) > 0 {
+			d.AppStateInfo.HealthyAlsoFromIngress = checkPublicHealth(k8sIngresses[k8sHealthCheckServiceName], app.Properties["healthCheckPath"])
+		}
+
 		if !d.AppStateInfo.HealthyAlsoFromIngress {
 			if len(k8sIngresses[k8sHealthCheckServiceName]) == 0 {
 				d.AppStateInfo.State = State_failed


### PR DESCRIPTION
Currently, we always call all public ingress endpoints even if we don't want to check them..
To avoid these additional calls we should only perform this kind of health check if it is configured.